### PR TITLE
Idler and tick to game server prefab

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,6 +1,0 @@
-{
-  "version": "1.0",
-  "components": [ 
-    "Microsoft.VisualStudio.Workload.ManagedGame"
-  ]
-} 

--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [ 
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+} 

--- a/Assets/Insight/Modules/Spawner/ProcessSpawner.cs
+++ b/Assets/Insight/Modules/Spawner/ProcessSpawner.cs
@@ -1,6 +1,7 @@
 ﻿using Mirror;
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
@@ -12,6 +13,8 @@ namespace Insight
         InsightServer server;
         InsightClient client;
 
+        public bool LogAll = true;
+
         [Header("Network")]
         [Tooltip("NetworkAddress that spawned processes will use")]
         public string SpawnerNetworkAddress = "localhost";
@@ -21,9 +24,12 @@ namespace Insight
         public int allocatedPorts = 1; //How many transports do you use in MultiplexTransport.
 
         [Header("Paths")]
+        [Tooltip("Example Mac filepath: /Users/yourName/Builds/")]
         public string EditorPath;
+        [Tooltip("Overwrite if builds are not all in same directory.")]
         public string ProcessPath;
         public string ProcessName;
+        private string PathResult;
 
         [Header("Threads")]
         public int MaximumProcesses = 5;
@@ -31,24 +37,67 @@ namespace Insight
         bool registrationComplete;
 
         public RunningProcessContainer[] spawnerProcesses;
+        private bool AbortRun = false;
 
         public override void Initialize(InsightServer server, ModuleManager manager)
         {
+
             this.server = server;
             RegisterHandlers();
         }
 
         public override void Initialize(InsightClient client, ModuleManager manager)
         {
+            if (AbortRun)
+                return;
             this.client = client;
             RegisterHandlers();
         }
 
         void Awake()
         {
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+            
+            // Mac adjustments to make life easier, user can just enter GameName.app like  windows
+            if (!ProcessName.Contains("/Contents/MacOS/"))
+            {
+                ProcessName = ProcessName + "/Contents/MacOS/" + ProcessName;
+
+                if (ProcessName.EndsWith(".app"))
+                {
+                    if (LogAll)
+                        Debug.Log("[ProcessSpawner] - Auto adjust path for OSX");
+                    ProcessName = ProcessName.Remove(ProcessName.Length - 4);
+                }
+            }
+
+            // Mac prefers not to use dot slash for same directory filepath
+            if (ProcessPath == "./")
+            {
+                if (LogAll)
+                    Debug.Log("[ProcessSpawner] - ProcessPath changed");
+                ProcessPath = "";
+            }
+#endif
+
 #if UNITY_EDITOR
             ProcessPath = EditorPath;
 #endif
+
+            PathResult = System.IO.Path.Combine(ProcessPath, ProcessName);
+
+            if (System.IO.File.Exists(PathResult))
+            {
+                if (LogAll)
+                    Debug.Log("[ProcessSpawner] - Path exists! " + PathResult);
+            }
+            else
+            {
+                if (LogAll)
+                    Debug.LogError("[ProcessSpawner] - Path does not exist. " + PathResult);
+                AbortRun = true;
+                return;
+            }
 
             spawnerProcesses = new RunningProcessContainer[MaximumProcesses];
             for (int i = 0; i < spawnerProcesses.Length; i++)
@@ -61,6 +110,8 @@ namespace Insight
 
         void FixedUpdate()
         {
+            if (AbortRun)
+                return;
             RegisterToMaster();
         }
 
@@ -110,7 +161,8 @@ namespace Insight
             {
                 if (client.isConnected)
                 {
-                    Debug.LogWarning("[ProcessSpawner] - Registering to Master");
+                    if (LogAll)
+                        Debug.Log("[ProcessSpawner] - Registering to Master");
                     client.Send(new RegisterSpawnerMsg()
                     {
                         UniqueID = "", //Can provide a password to authenticate to the master as a trusted spawner
@@ -124,16 +176,17 @@ namespace Insight
         void CheckSpawnedProcessHealth()
         {
             //Check to see if a previously running process exited without warning
-            for(int i = 0; i < spawnerProcesses.Length; i++)
+            for (int i = 0; i < spawnerProcesses.Length; i++)
             {
-                if(spawnerProcesses[i].process == null)
+                if (spawnerProcesses[i].process == null)
                 {
                     continue;
                 }
 
                 if (spawnerProcesses[i].process.HasExited)
                 {
-                    Debug.Log("Removing process that has exited");
+                    if (LogAll)
+                        Debug.Log("Removing process that has exited");
                     spawnerProcesses[i].process = null;
                     spawnerProcesses[i].pid = 0;
                     spawnerProcesses[i].uniqueID = "";
@@ -142,7 +195,7 @@ namespace Insight
             }
 
             //If running as a remote spawner report the current running process count back to the MasterSpawner
-            if(client != null)
+            if (client != null)
             {
                 client.Send(new SpawnerStatusMsg()
                 {
@@ -155,7 +208,7 @@ namespace Insight
         {
             KillSpawnMsg message = netMsg.ReadMessage<KillSpawnMsg>();
 
-            for(int i = 0; i < spawnerProcesses.Length; i++)
+            for (int i = 0; i < spawnerProcesses.Length; i++)
             {
                 if (spawnerProcesses[i].uniqueID.Equals(message.UniqueID))
                 {
@@ -181,7 +234,8 @@ namespace Insight
             {
                 spawnProperties.UniqueID = Guid.NewGuid().ToString();
 
-                Debug.LogWarning("[ProcessSpawner] - UniqueID was not provided for spawn. Generating: " + spawnProperties.UniqueID);
+                if (LogAll)
+                    Debug.Log("[ProcessSpawner] - UniqueID was not provided for spawn. Generating: " + spawnProperties.UniqueID);
             }
 
             Process p = new Process();
@@ -192,13 +246,25 @@ namespace Insight
             //Args to pass: Port, Scene, UniqueID...
             p.StartInfo.Arguments = ArgsString() +
                 " -NetworkAddress " + SpawnerNetworkAddress +
-                " -NetworkPort " + (StartingNetworkPort + thisPort * allocatedPorts) + 
+                " -NetworkPort " + (StartingNetworkPort + thisPort * allocatedPorts) +
                 " -SceneName " + spawnProperties.SceneName +
                 " -UniqueID " + spawnProperties.UniqueID; //What to do if the UniqueID or any other value is null??
 
+            if (System.IO.File.Exists(p.StartInfo.FileName))
+            {
+                if (LogAll)
+                    Debug.Log("[ProcessSpawner] - Path exists!" + p.StartInfo.FileName);
+            }
+            else
+            {
+                Debug.LogError("[ProcessSpawner] - Path does not exist. " + p.StartInfo.FileName);
+                return false;
+            }
+
             if (p.Start())
             {
-                Debug.Log("[ProcessSpawner]: spawning: " + p.StartInfo.FileName + "; args=" + p.StartInfo.Arguments);
+                if (LogAll)
+                    Debug.Log("[ProcessSpawner]: spawning: " + p.StartInfo.FileName + "; args=" + p.StartInfo.Arguments);
             }
             else
             {
@@ -226,24 +292,25 @@ namespace Insight
 
         int GetPort()
         {
-            for(int i = 0; i < spawnerProcesses.Length; i++)
+            for (int i = 0; i < spawnerProcesses.Length; i++)
             {
-                if(spawnerProcesses[i].process == null)   
+                if (spawnerProcesses[i].process == null)
                 {
                     return i;
                 }
             }
 
-            Debug.LogError("[ProcessSpawner] - Maximum Process Count Reached");
+            //if (LogAll) important to display, but do not flag as error
+            Debug.LogWarning("[ProcessSpawner] - Maximum Process Count Reached");
             return -1;
         }
 
         int GetRunningProcessCount()
         {
             int counter = 0;
-            for(int i = 0; i < spawnerProcesses.Length; i++)
+            for (int i = 0; i < spawnerProcesses.Length; i++)
             {
-                if(spawnerProcesses[i].process != null)   
+                if (spawnerProcesses[i].process != null)
                 {
                     counter++;
                 }

--- a/Assets/Insight/Prefabs/GameServer(InsightClient).prefab
+++ b/Assets/Insight/Prefabs/GameServer(InsightClient).prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 4096983759368602}
   - component: {fileID: 114424672232905856}
   - component: {fileID: 114092492723764628}
+  - component: {fileID: 5718592856820291868}
   - component: {fileID: 2900258155413334504}
   m_Layer: 0
   m_Name: GameServer(InsightClient)
@@ -31,6 +32,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4071960391454292}
+  - {fileID: 4847061854013595876}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -64,6 +66,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SearchChildrenForModule: 1
+--- !u!114 &5718592856820291868
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1763708289631472}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb0d041cec9b6024cb9d602693343932, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tickRate: 30
 --- !u!114 &2900258155413334504
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -131,9 +146,55 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 72fd0eb9c3a916a42b979bafd1098e66, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  LogAll: 1
   GameScene: 
   NetworkAddress: 
   NetworkPort: 0
   UniqueID: 
   MaxPlayers: 0
   CurrentPlayers: 0
+  verifiedScenes: []
+--- !u!1 &1030115387926320301
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4847061854013595876}
+  - component: {fileID: 5808198851111840231}
+  m_Layer: 0
+  m_Name: GameIdler
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4847061854013595876
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030115387926320301}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4096983759368602}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5808198851111840231
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030115387926320301}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dcf7450b2b35ad949a5b27a12ab00aed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MaxMinutesOfIdle: 5


### PR DESCRIPTION
2 things the prefab should have on by default IMO

Tick rate script added to GameServer prefab parent, to prevent it running at uncapped max cpu.
(if you havnt marked and built as headless build, NetworkManagers tickrate wont be used, and/or vsync if off).

Idler script added as a child module to GameServer, with 5 min as default closing time of in-activity.
Otherwise they'l never close, could end up with 5+ GameServers just sitting their with 0 players.