### PR TITLE
Stop duplicate registered users check.

### DIFF
--- a/Assets/Insight/Modules/Login/ServerAuthentication.cs
+++ b/Assets/Insight/Modules/Login/ServerAuthentication.cs
@@ -12,6 +12,8 @@ namespace Insight
         InsightServer server;
 
         public List<UserContainer> registeredUsers = new List<UserContainer>();
+        
+        private string UniqueId = "";
 
         public override void Initialize(InsightServer server, ModuleManager manager)
         {
@@ -40,7 +42,7 @@ namespace Insight
                 //Check the username and password. Again this is bad code for example only. REPLACE ME
                 if (message.AccountName.Equals("root") && message.AccountPassword.Equals("password"))
                 {
-                    string UniqueId = Guid.NewGuid().ToString();
+                    UniqueId = Guid.NewGuid().ToString();
 
                     if (GetUserByConnection(netMsg.connectionId) == null)
                     {
@@ -77,7 +79,7 @@ namespace Insight
                 // A check to stop duplicate registered users, either from glitches, or client abuse.
                 if (GetUserByConnection(netMsg.connectionId) == null)
                 {
-                    string UniqueId = Guid.NewGuid().ToString();
+                    UniqueId = Guid.NewGuid().ToString();
 
                     registeredUsers.Add(new UserContainer()
                     {

--- a/Assets/Insight/Modules/Login/ServerAuthentication.cs
+++ b/Assets/Insight/Modules/Login/ServerAuthentication.cs
@@ -40,14 +40,21 @@ namespace Insight
                 //Check the username and password. Again this is bad code for example only. REPLACE ME
                 if (message.AccountName.Equals("root") && message.AccountPassword.Equals("password"))
                 {
-                    string UniqueId = Guid.NewGuid().ToString();
+                     string UniqueId = Guid.NewGuid().ToString();
 
-                    registeredUsers.Add(new UserContainer()
+                    if (GetUserByConnection(netMsg.connectionId) == null)
                     {
-                        username = message.AccountName,
-                        uniqueId = UniqueId,
-                        connectionId = netMsg.connectionId
-                    });
+                        registeredUsers.Add(new UserContainer()
+                        {
+                            username = message.AccountName,
+                            uniqueId = UniqueId,
+                            connectionId = netMsg.connectionId
+                        });
+                    }
+                    else
+                    {
+                        UniqueId = GetUserByConnection(netMsg.connectionId).uniqueId;
+                    }
 
                     netMsg.Reply(new LoginResponseMsg()
                     {
@@ -67,14 +74,18 @@ namespace Insight
             }
             else
             {
-                string UniqueId = Guid.NewGuid().ToString();
-
-                registeredUsers.Add(new UserContainer()
+                // A check to stop duplicate registered users, either from glitches, or client abuse.
+                if (GetUserByConnection(netMsg.connectionId) == null)
                 {
-                    username = message.AccountName,
-                    uniqueId = UniqueId,
-                    connectionId = netMsg.connectionId
-                });
+                    string UniqueId = Guid.NewGuid().ToString();
+
+                    registeredUsers.Add(new UserContainer()
+                    {
+                        username = message.AccountName,
+                        uniqueId = UniqueId,
+                        connectionId = netMsg.connectionId
+                    });
+                }
 
                 netMsg.Reply(new LoginResponseMsg()
                 {

--- a/Assets/Insight/Modules/Login/ServerAuthentication.cs
+++ b/Assets/Insight/Modules/Login/ServerAuthentication.cs
@@ -40,7 +40,7 @@ namespace Insight
                 //Check the username and password. Again this is bad code for example only. REPLACE ME
                 if (message.AccountName.Equals("root") && message.AccountPassword.Equals("password"))
                 {
-                     string UniqueId = Guid.NewGuid().ToString();
+                    string UniqueId = Guid.NewGuid().ToString();
 
                     if (GetUserByConnection(netMsg.connectionId) == null)
                     {


### PR DESCRIPTION
A check to stop duplicate registered users, either from glitches, or client abuse.